### PR TITLE
Fixed bad path in linux launch script

### DIFF
--- a/LinuxLevinux.sh
+++ b/LinuxLevinux.sh
@@ -6,7 +6,7 @@ else
 	echo "Resize is not installed.  Levinux is best used in a 25x80 terminal." 2>&1
 fi
 
-cd ./Pipulate.app/Contents/MacOS/
+cd ./Levinux.app/Contents/MacOS/
 
 ./qemu-system-i386 -curses \
 -kernel vmlinuz \


### PR DESCRIPTION
The path in the linux launch script was changed to make the script
work correctly. 'cd ./Pipulate.app/Contents/MacOS/' was changed to
'cd ./Levinux.app/Contents/MacOS/'.